### PR TITLE
Adding HashiCorp Consul Profile to Weave GitOps

### DIFF
--- a/charts/consul/.helmignore
+++ b/charts/consul/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/consul/Chart.yaml
+++ b/charts/consul/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v2
+name: consul
+icon: https://symbols.getvecta.com/stencil_77/63_consul-icon.c960aeea49.svg
+description: A Weaveworks Helm chart for the HashiCorp Consul Profile
+type: application
+version: 1.12.0
+dependencies:
+  - name: consul
+    version: "~0.44.0"
+    repository: "https://helm.releases.hashicorp.com"
+kubeVersion: ">=1.16.0-0"
+home: https://github.com/weaveworks/profiles-catalog
+sources:
+  - https://helm.releases.hashicorp.com
+
+keywords:
+- hashicorp
+- consul
+
+maintainers:
+  - name: Weaveworks
+    email: support@weave.works
+
+annotations:
+  "weave.works/profile": consul
+  "weave.works/category": Infrastructure
+  "weave.works/links": |
+    - name: Chart Sources
+      url: https://helm.releases.hashicorp.com
+    - name: Upstream Project
+      url: https://github.com/hashicorp/consul-k8s
+  "weave.works/profile-ci": |
+    - "gke"
+    - "kind"

--- a/charts/consul/values.yaml
+++ b/charts/consul/values.yaml
@@ -1,0 +1,11 @@
+global:
+  name: consul
+  datacenter: dc1
+server:
+  replicas: 1
+ui:
+  enabled: true
+connectInject:
+  enabled: true
+controller:
+  enabled: true


### PR DESCRIPTION
- Latest chart and app version available
- `values.yaml` has `replicas` only set to `1`, this is due to **podAntiAffinity** preventing running multiple replicas in a single node aka kind environment. Opted that it is better to reduce replicas than set `affinity` as `null`.
- Tested locally by running `kubectl port-forward consul-server-0 --namespace consul 8500:8500` and am able to view Consul UI successfully