### PR TITLE
Adding HashiCorp Vault Profile to Weave GitOps

### DIFF
--- a/charts/vault/.helmignore
+++ b/charts/vault/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -1,0 +1,34 @@
+apiVersion: v2
+name: vault
+icon: https://www.datocms-assets.com/2885/1620155128-brandhcvaultverticalcolor.svg
+description: A Weaveworks Helm chart for the HashiCorp Vault Profile
+type: application
+version: 1.10.3
+dependencies:
+  - name: vault
+    version: "~0.20.1"
+    repository: "https://helm.releases.hashicorp.com "
+kubeVersion: ">=1.16.0-0"
+home: https://github.com/weaveworks/profiles-catalog
+sources:
+  - https://helm.releases.hashicorp.com
+
+keywords:
+- hashicorp
+- vault
+
+maintainers:
+  - name: Weaveworks
+    email: support@weave.works
+
+annotations:
+  "weave.works/profile": vault
+  "weave.works/category": Infrastructure
+  "weave.works/links": |
+    - name: Chart Sources
+      url: https://helm.releases.hashicorp.com
+    - name: Upstream Project
+      url: https://github.com/hashicorp/vault-k8s
+  "weave.works/profile-ci": |
+    - "gke"
+    - "kind"

--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -7,7 +7,7 @@ version: 1.10.3
 dependencies:
   - name: vault
     version: "~0.20.1"
-    repository: "https://helm.releases.hashicorp.com "
+    repository: "https://helm.releases.hashicorp.com"
 kubeVersion: ">=1.16.0-0"
 home: https://github.com/weaveworks/profiles-catalog
 sources:

--- a/charts/vault/Chart.yaml
+++ b/charts/vault/Chart.yaml
@@ -3,7 +3,8 @@ name: vault
 icon: https://www.datocms-assets.com/2885/1620155128-brandhcvaultverticalcolor.svg
 description: A Weaveworks Helm chart for the HashiCorp Vault Profile
 type: application
-version: 1.10.3
+# this is the Weave GitOps Profile version, not the Helm chart|app version
+version: 0.0.1
 dependencies:
   - name: vault
     version: "~0.20.1"

--- a/charts/vault/values.yaml
+++ b/charts/vault/values.yaml
@@ -1,0 +1,3 @@
+vault:
+  ui:
+    enabled: true


### PR DESCRIPTION
- Latest chart and app version available
- `values.yaml` is quite bare as Vault is a highly opinionated security swiss army knife. This should be down to the Profiles user to configure
- Tested locally by running `kubectl port-forward vault-vault-0 8200:8200 -n vault` and am able to view Vault UI successfully

NB: `ha` can be set, however it is default to `false`. If is is enabled, the default backend is Consul, which would imply a depends on https://github.com/weaveworks/profiles-catalog/pull/158


