### PR TITLE
Add metallb profile

### DIFF
--- a/charts/metallb/.helmignore
+++ b/charts/metallb/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/metallb/Chart.lock
+++ b/charts/metallb/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: metallb
+  repository: https://metallb.github.io/metallb
+  version: 0.13.3
+digest: sha256:f5075b9011e5b03dc7dc029a0ce2c2094cc85825d8f1ab0c5274db092d2a8e96
+generated: "2022-07-11T17:36:17.965016099+01:00"

--- a/charts/metallb/Chart.yaml
+++ b/charts/metallb/Chart.yaml
@@ -1,0 +1,36 @@
+apiVersion: v2
+name: metallb
+icon: https://metallb.universe.tf/images/logo/metallb-white.png
+description: A Weaveworks Helm chart for a network load-balancer implementation for Kubernetes using standard routing protocols
+type: application
+version: 0.0.1
+dependencies:
+  - name: metallb
+    version: "v0.13.3"
+    repository: "https://metallb.github.io/metallb"
+kubeVersion: ">=1.16.0-0"
+home: https://github.com/weaveworks/profiles-catalog
+sources:
+  - https://metallb.github.io/metallb
+
+keywords:
+- metallb
+- loadbalancer
+- kind
+
+maintainers:
+  - name: Weaveworks
+    email: support@weave.works
+
+annotations:
+  "weave.works/profile": metallb
+  "weave.works/category": Loadbalancer
+  "weave.works/layer": layer-0
+  "weave.works/operator": "false"
+  "weave.works/links": |
+    - name: Chart Sources
+      url: https://metallb.github.io/metallb
+    - name: Upstream Project
+      url: https://github.com/metallb/metallb
+  "weave.works/profile-ci": |
+    - "kind"

--- a/charts/metallb/templates/NOTES.txt
+++ b/charts/metallb/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "metallb.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "metallb.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "metallb.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "metallb.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/metallb/templates/_helpers.tpl
+++ b/charts/metallb/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "metallb.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "metallb.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "metallb.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "metallb.labels" -}}
+helm.sh/chart: {{ include "metallb.chart" . }}
+{{ include "metallb.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "metallb.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "metallb.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "metallb.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "metallb.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -1,0 +1,7 @@
+prometheus:
+  #Set the prometheus namespace if podMonitor is enabled
+  namespace: ""
+  podMonitor:
+    enabled: false
+  prometheusRule:
+    enabled: false

--- a/charts/metallb/values.yaml
+++ b/charts/metallb/values.yaml
@@ -5,3 +5,11 @@ prometheus:
     enabled: false
   prometheusRule:
     enabled: false
+configInline:
+  address-pools:
+    - name: default
+      protocol: layer2
+      #replace the address with a subnet address range for your environment
+      addresses:
+      - 192.168.168.0/24
+


### PR DESCRIPTION
Create a new metallb profile.
To be used with Kind and Liquidmetal clusters to provide a loadbalancer service to bare metal clusters.

You must customise the IP address range in the values.yaml for each environment.
