### PR TITLE
add local-path-provisioner profile for LM and Kind clusters

### DIFF
--- a/charts/local-path-provisioner/.helmignore
+++ b/charts/local-path-provisioner/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/local-path-provisioner/Chart.lock
+++ b/charts/local-path-provisioner/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: local-path-provisioner
+  repository: ""
+  version: v0.0.22-dev
+digest: sha256:6c957a41ce1261989090a9d5a4cd73697c5c4ea2743b25841ddc6d2e0a269551
+generated: "2022-09-02T10:12:19.378410737+01:00"

--- a/charts/local-path-provisioner/Chart.yaml
+++ b/charts/local-path-provisioner/Chart.yaml
@@ -1,0 +1,31 @@
+apiVersion: v2
+description: Weaveworks profile for HostPath for persistent local storage with Kubernetes based on Rancher
+name: local-path-provisioner
+version: 0.0.3
+appVersion: "v0.0.22-dev"
+kubeVersion: ">=1.12.0-r0"
+home: https://github.com/weaveworks/profiles-catalog
+sources:
+  - https://github.com/rancher/local-path-provisioner.git
+dependencies:
+  - name: local-path-provisioner
+    version: "v0.0.22-dev"
+keywords:
+- local-path-provisioner
+- kind
+- storage
+- hostpath
+maintainers:
+  - name: Weaveworks
+    email: support@weave.works
+annotations:
+  "weave.works/profile": local-path-provisioner
+  "weave.works/category": Storage
+  "weave.works/layer": layer-0
+  "weave.works/links": |
+    - name: Chart Sources
+      url: https://github.com/weaveworks/profiles-catalog.git
+    - name: Upstream Project
+      url: https://github.com/rancher/local-path-provisioner.git
+  "weave.works/profile-ci": |
+    - "kind"

--- a/charts/local-path-provisioner/README.md
+++ b/charts/local-path-provisioner/README.md
@@ -1,0 +1,15 @@
+# Local path provisioner profile for weave gitops
+
+This profile is based on the local-path-provisioner from Rancher.
+The Rancher Helm chart is used as a subchart.
+
+This profile will set the local-path-provisioner as the default storage class.
+
+## Uupgrading the Rancher chart
+
+As the Rancher chart is not published in a Helm repository,
+to update the version you will have to download the chart from:
+https://github.com/rancher/local-path-provisioner/tree/master/deploy/chart/local-path-provisioner
+And copy that into the /charts folder.
+
+Also remember to update the version in the profile's Chart.yaml to refer to the Rancher chart version.

--- a/charts/local-path-provisioner/charts/local-path-provisioner/.helmignore
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/local-path-provisioner/charts/local-path-provisioner/Chart.yaml
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+description: Use HostPath for persistent local storage with Kubernetes
+name: local-path-provisioner
+version: 0.0.22-dev
+appVersion: "v0.0.22-dev"
+keywords:
+  - storage
+  - hostpath
+kubeVersion: ">=1.12.0-r0"
+home: https://github.com/rancher/local-path-provisioner
+sources:
+  - https://github.com/rancher/local-path-provisioner.git

--- a/charts/local-path-provisioner/charts/local-path-provisioner/README.md
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/README.md
@@ -1,0 +1,116 @@
+# Local Path Provisioner
+
+[Local Path Provisioner](https://github.com/rancher/local-path-provisioner) provides a way for the Kubernetes users to
+utilize the local storage in each node. Based on the user configuration, the Local Path Provisioner will create
+`hostPath` based persistent volume on the node automatically. It utilizes the features introduced by Kubernetes [Local
+Persistent Volume feature](https://kubernetes.io/blog/2018/04/13/local-persistent-volumes-beta/), but make it a simpler
+solution than the built-in `local` volume feature in Kubernetes.
+
+## TL;DR;
+
+```console
+$ git clone https://github.com/rancher/local-path-provisioner.git
+$ cd local-path-provisioner
+$ helm install --name local-path-storage --namespace local-path-storage ./deploy/chart/
+```
+
+## Introduction
+
+This chart bootstraps a [Local Path Provisioner](https://github.com/rancher/local-path-provisioner) deployment on a
+[Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
+
+## Prerequisites
+
+- Kubernetes 1.12+ with Beta APIs enabled
+
+## Installing the Chart
+
+To install the chart with the release name `local-path-storage`:
+
+```console
+$ git clone https://github.com/rancher/local-path-provisioner.git
+$ cd local-path-provisioner
+$ helm install ./deploy/chart/ --name local-path-storage --namespace local-path-storage
+```
+
+The command deploys Local Path Provisioner on the Kubernetes cluster in the default configuration. The
+[configuration](#configuration) section lists the parameters that can be configured during installation.
+
+> **Tip**: List all releases using `helm list`
+
+## Uninstalling the Chart
+
+To uninstall/delete the `local-path-storage` deployment:
+
+```console
+$ helm delete --purge local-path-storage
+```
+
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the configurable parameters of the Local Path Provisioner for Kubernetes chart and their
+default values.
+
+| Parameter                           | Description                                                                     | Default                                                                             |
+| ----------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `image.repository`                  | Local Path Provisioner image name                                               | `rancher/local-path-provisioner`                                                    |
+| `image.tag`                         | Local Path Provisioner image tag                                                | `master-head`                                                                       |
+| `image.pullPolicy`                  | Image pull policy                                                               | `IfNotPresent`                                                                      |
+| `storageClass.create`               | If true, create a `StorageClass`                                                | `true`                                                                              |
+| `storageClass.provisionerName`      | The provisioner name for the storage class                                      | `nil`                                                                               |
+| `storageClass.defaultClass`         | If true, set the created `StorageClass` as the cluster's default `StorageClass` | `false`                                                                             |
+| `storageClass.name`                 | The name to assign the created StorageClass                                     | local-path                                                                          |
+| `storageClass.reclaimPolicy`        | ReclaimPolicy field of the class                                                | Delete                                                                              |
+| `nodePathMap`                       | Configuration of where to store the data on each node                           | `[{node: DEFAULT_PATH_FOR_NON_LISTED_NODES, paths: [/opt/local-path-provisioner]}]` |
+| `resources`                         | Local Path Provisioner resource requests & limits                               | `{}`                                                                                |
+| `rbac.create`                       | If true, create & use RBAC resources                                            | `true`                                                                              |
+| `serviceAccount.create`             | If true, create the Local Path Provisioner service account                      | `true`                                                                              |
+| `serviceAccount.name`               | Name of the Local Path Provisioner service account to use or create             | `nil`                                                                               |
+| `nodeSelector`                      | Node labels for Local Path Provisioner pod assignment                           | `{}`                                                                                |
+| `tolerations`                       | Node taints to tolerate                                                         | `[]`                                                                                |
+| `affinity`                          | Pod affinity                                                                    | `{}`                                                                                |
+| `configmap.setup`                   | Configuration of script to execute setup operations on each node                | #!/bin/sh<br>while getopts "m:s:p:" opt<br>do<br>&emsp;case $opt in <br>&emsp;&emsp;p)<br>&emsp;&emsp;absolutePath=$OPTARG<br>&emsp;&emsp;;;<br>&emsp;&emsp;s)<br>&emsp;&emsp;sizeInBytes=$OPTARG<br>&emsp;&emsp;;;<br>&emsp;&emsp;m)<br>&emsp;&emsp;volMode=$OPTARG<br>&emsp;&emsp;;;<br>&emsp;esac<br>done<br>mkdir -m 0777 -p ${absolutePath}                                    |
+| `configmap.teardown`                | Configuration of script to execute teardown operations on each node             | #!/bin/sh<br>while getopts "m:s:p:" opt<br>do<br>&emsp;case $opt in <br>&emsp;&emsp;p)<br>&emsp;&emsp;absolutePath=$OPTARG<br>&emsp;&emsp;;;<br>&emsp;&emsp;s)<br>&emsp;&emsp;sizeInBytes=$OPTARG<br>&emsp;&emsp;;;<br>&emsp;&emsp;m)<br>&emsp;&emsp;volMode=$OPTARG<br>&emsp;&emsp;;;<br>&emsp;esac<br>done<br>rm -rf ${absolutePath}                                              |
+| `configmap.name`                    | configmap name                                                                  | `local-path-config`                                                                 |
+| `configmap.helperPod`               | helper pod yaml file                                                            | apiVersion: v1<br>kind: Pod<br>metadata:<br>&emsp;name: helper-pod<br>spec:<br>&emsp;containers:<br>&emsp;- name: helper-pod<br>&emsp;&emsp;image: busybox |
+
+
+Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
+
+```console
+$ helm install ./deploy/chart/ --name local-path-storage --namespace local-path-storage --set storageClass.provisionerName=rancher.io/local-path
+```
+
+Alternatively, a YAML file that specifies the values for the above parameters can be provided while installing the
+chart. For example,
+
+```console
+$ helm install --name local-path-storage --namespace local-path-storage ./deploy/chart/ -f values.yaml
+```
+
+> **Tip**: You can use the default [values.yaml](values.yaml)
+
+## RBAC
+
+By default the chart will install the recommended RBAC roles and rolebindings.
+
+You need to have the flag `--authorization-mode=RBAC` on the api server. See the following document for how to enable
+[RBAC](https://kubernetes.io/docs/admin/authorization/rbac/).
+
+To determine if your cluster supports RBAC, run the following command:
+
+```console
+$ kubectl api-versions | grep rbac
+```
+
+If the output contains "beta", you may install the chart with RBAC enabled (see below).
+
+### Enable RBAC role/rolebinding creation
+
+To enable the creation of RBAC resources (On clusters with RBAC). Do the following:
+
+```console
+$ helm install ./deploy/chart/ --name local-path-storage --namespace local-path-storage --set rbac.create=true
+```

--- a/charts/local-path-provisioner/charts/local-path-provisioner/templates/NOTES.txt
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/templates/NOTES.txt
@@ -1,0 +1,13 @@
+You can create a hostpath-backed persistent volume with a persistent volume claim like this:
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: local-path-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: {{ .Values.storageClass.name }}
+  resources:
+    requests:
+      storage: 2Gi

--- a/charts/local-path-provisioner/charts/local-path-provisioner/templates/_helpers.tpl
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "local-path-provisioner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "local-path-provisioner.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "local-path-provisioner.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "local-path-provisioner.labels" -}}
+app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}
+helm.sh/chart: {{ include "local-path-provisioner.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "local-path-provisioner.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "local-path-provisioner.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the provisioner to use.
+*/}}
+{{- define "local-path-provisioner.provisionerName" -}}
+{{- if .Values.storageClass.provisionerName -}}
+{{- printf .Values.storageClass.provisionerName -}}
+{{- else -}}
+cluster.local/{{ template "local-path-provisioner.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "local-path-provisioner.secret" }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.privateRegistry.registryUrl (printf "%s:%s" .Values.privateRegistry.registryUser .Values.privateRegistry.registryPasswd | b64enc) | b64enc }}
+{{- end }}

--- a/charts/local-path-provisioner/charts/local-path-provisioner/templates/clusterrole.yaml
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/templates/clusterrole.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "local-path-provisioner.fullname" . }}
+  labels:
+{{ include "local-path-provisioner.labels" . | indent 4 }}
+rules:
+- apiGroups: [""]
+  resources: ["nodes", "persistentvolumeclaims", "configmaps"]
+  verbs: ["get", "list", "watch"]
+- apiGroups: [""]
+  resources: ["endpoints", "persistentvolumes", "pods"]
+  verbs: ["*"]
+- apiGroups: [""]
+  resources: ["events"]
+  verbs: ["create", "patch"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
+  verbs: ["get", "list", "watch"]
+{{- end -}}

--- a/charts/local-path-provisioner/charts/local-path-provisioner/templates/clusterrolebinding.yaml
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/templates/clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.rbac.create -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "local-path-provisioner.fullname" . }}
+  labels:
+{{ include "local-path-provisioner.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "local-path-provisioner.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "local-path-provisioner.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}

--- a/charts/local-path-provisioner/charts/local-path-provisioner/templates/configmap.yaml
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/templates/configmap.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.configmap.name }}
+  labels:
+{{ include "local-path-provisioner.labels" . | indent 4 }}
+data:
+  config.json: |-
+    {
+      "nodePathMap": {{ .Values.nodePathMap | toPrettyJson | nindent 8 }}
+    }
+  setup: |-
+    {{ .Values.configmap.setup | nindent 4 }}
+  teardown: |-
+    {{ .Values.configmap.teardown | nindent 4 }}
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      containers:
+        - name: helper-pod
+          {{- if .Values.privateRegistry.registryUrl }}
+          image: {{ .Values.privateRegistry.registryUrl }}/{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}
+          {{- else }}
+          image: {{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}
+          {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/local-path-provisioner/charts/local-path-provisioner/templates/deployment.yaml
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/templates/deployment.yaml
@@ -1,0 +1,85 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "local-path-provisioner.fullname" . }}
+  labels:
+{{ include "local-path-provisioner.labels" . | indent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+    {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+      serviceAccountName: {{ template "local-path-provisioner.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+        {{- if .Values.privateRegistry.registryUrl }}
+          image: "{{ .Values.privateRegistry.registryUrl }}/{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- else }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        {{- end }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - local-path-provisioner
+            - --debug
+            - start
+            - --config
+            - /etc/config/config.json
+            - --service-account-name
+            - {{ template "local-path-provisioner.serviceAccountName" . }}
+            - --provisioner-name
+            - {{ template "local-path-provisioner.provisionerName" . }}
+            - --helper-image
+          {{- if .Values.privateRegistry.registryUrl }}
+            - "{{ .Values.privateRegistry.registryUrl }}/{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
+          {{- else }}
+            - "{{ .Values.helperImage.repository }}:{{ .Values.helperImage.tag }}"
+          {{- end }}
+            - --configmap-name
+            - {{ .Values.configmap.name }}
+          {{- if .Values.workerThreads }}
+            - --worker-threads
+            - {{ .Values.workerThreads }}
+          {{- end }}
+          {{- if .Values.provisioningRetryCount }}
+            - --provisioning-retry-count
+            - {{ .Values.provisioningRetryCount }}
+          {{- end }}
+          {{- if .Values.deletionRetryCount }}
+            - --deletion-retry-count
+            - {{ .Values.deletionRetryCount }}
+          {{- end }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/config/
+          env:
+            - name: POD_NAMESPACE
+              value: {{ .Release.Namespace }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: config-volume
+          configMap:
+            name: {{ .Values.configmap.name }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/local-path-provisioner/charts/local-path-provisioner/templates/registry-secret.yaml
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/templates/registry-secret.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.defaultSettings.registrySecret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.defaultSettings.registrySecret }}
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "local-path-provisioner.secret" . }}
+{{- end }}

--- a/charts/local-path-provisioner/charts/local-path-provisioner/templates/serviceaccount.yaml
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "local-path-provisioner.serviceAccountName" . }}
+  labels:
+{{ include "local-path-provisioner.labels" . | indent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- if .Values.defaultSettings.registrySecret }}
+  - name: {{ .Values.defaultSettings.registrySecret }}
+{{- end }}
+{{- end }}

--- a/charts/local-path-provisioner/charts/local-path-provisioner/templates/storageclass.yaml
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/templates/storageclass.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.storageClass.create -}}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.storageClass.name }}
+  labels:
+{{ include "local-path-provisioner.labels" . | indent 4 }}
+{{- if .Values.storageClass.defaultClass }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+{{- end }}
+provisioner: {{ template "local-path-provisioner.provisionerName" . }}
+volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
+allowVolumeExpansion: true
+{{- end }}

--- a/charts/local-path-provisioner/charts/local-path-provisioner/values.yaml
+++ b/charts/local-path-provisioner/charts/local-path-provisioner/values.yaml
@@ -1,0 +1,110 @@
+# Default values for local-path-provisioner.
+
+replicaCount: 1
+
+image:
+  repository: rancher/local-path-provisioner
+  tag: master-head
+  pullPolicy: IfNotPresent
+
+helperImage:
+  repository: busybox
+  tag: latest
+
+defaultSettings:
+  registrySecret: ~
+
+privateRegistry:
+  registryUrl: ~
+  registryUser: ~
+  registryPasswd: ~
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+## For creating the StorageClass automatically:
+storageClass:
+  create: true
+
+  ## Set a provisioner name. If unset, a name will be generated.
+  # provisionerName: rancher.io/local-path
+
+  ## Set StorageClass as the default StorageClass
+  ## Ignored if storageClass.create is false
+  defaultClass: false
+
+  ## Set a StorageClass name
+  ## Ignored if storageClass.create is false
+  name: local-path
+
+  ## ReclaimPolicy field of the class, which can be either Delete or Retain
+  reclaimPolicy: Delete
+
+# nodePathMap is the place user can customize where to store the data on each node.
+# 1. If one node is not listed on the nodePathMap, and Kubernetes wants to create volume on it, the paths specified in
+#    DEFAULT_PATH_FOR_NON_LISTED_NODES will be used for provisioning.
+# 2. If one node is listed on the nodePathMap, the specified paths will be used for provisioning.
+#     1. If one node is listed but with paths set to [], the provisioner will refuse to provision on this node.
+#     2. If more than one path was specified, the path would be chosen randomly when provisioning.
+#
+# The configuration must obey following rules:
+# 1. A path must start with /, a.k.a an absolute path.
+# 2. Root directory (/) is prohibited.
+# 3. No duplicate paths allowed for one node.
+# 4. No duplicate node allowed.
+nodePathMap:
+  - node: DEFAULT_PATH_FOR_NON_LISTED_NODES
+    paths:
+      - /opt/local-path-provisioner
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+rbac:
+  # Specifies whether RBAC resources should be created
+  create: true
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: true
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+configmap:
+  # specify the config map name
+  name: local-path-config
+  # specify the custom script for setup and teardown
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"
+
+# Number of provisioner worker threads to call provision/delete simultaneously.
+# workerThreads: 4
+
+# Number of retries of failed volume provisioning. 0 means retry indefinitely.
+# provisioningRetryCount: 15
+
+# Number of retries of failed volume deletion. 0 means retry indefinitely.
+# deletionRetryCount: 15

--- a/charts/local-path-provisioner/templates/NOTES.txt
+++ b/charts/local-path-provisioner/templates/NOTES.txt
@@ -1,0 +1,3 @@
+Thank you for installing {{ .Chart.Name }} {{ .Chart.Version }} 😀
+
+Your release is named {{ .Release.Name }}, app version {{ .Chart.AppVersion }}

--- a/charts/local-path-provisioner/templates/_helpers.tpl
+++ b/charts/local-path-provisioner/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "local-path-provisioner.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "local-path-provisioner.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "local-path-provisioner.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "local-path-provisioner.labels" -}}
+helm.sh/chart: {{ include "local-path-provisioner.chart" . }}
+{{ include "local-path-provisioner.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "local-path-provisioner.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "local-path-provisioner.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "local-path-provisioner.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "local-path-provisioner.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/local-path-provisioner/values.yaml
+++ b/charts/local-path-provisioner/values.yaml
@@ -1,0 +1,3 @@
+local-path-provisioner:
+  storageClass:
+    defaultClass: true


### PR DESCRIPTION
This profile is needed for the demo environments to use with LiquidMetal clusters that need storage.
It uses the Rancher local-path-provisioner Helm chart as a subchart.
Rancher do not publish this chart in a Helm repository, so it needs to be maintained here.

The profile then sets this storage as the default storage class.