### PR TITLE
Upgrade flux resources to v1 in weave-policy-agent

### DIFF
--- a/charts/external-secrets/Bootstrapping-Guide.md
+++ b/charts/external-secrets/Bootstrapping-Guide.md
@@ -10,9 +10,9 @@ In Flux, we can't have dependencies between Flux Kustomization and HelmRelease, 
 
 Both controllers manage the resources independently, at different moments, with no possibility to wait for each other. This means that we have a wonderful race condition where sometimes the CRs (`SecretStore`,`ClusterSecretStore`...) tries to be deployed before than the CRDs needed to recognize them.
 
-Reference: [https://external-secrets.io/v0.6.1/examples/gitops-using-fluxcd/](https://external-secrets.io/v0.6.1/examples/gitops-using-fluxcd/) 
+Reference: [https://external-secrets.io/v0.6.1/examples/gitops-using-fluxcd/](https://external-secrets.io/v0.6.1/examples/gitops-using-fluxcd/)
 
- 
+
 
 ## The solution
 
@@ -53,7 +53,7 @@ Let's see the conditions to start working on a solution:
 
 - ***cluster-secrets/cluster-secrets.yaml***
 
-This file will contain the main configurations and requirements to install secret management operator and all its dependencies 
+This file will contain the main configurations and requirements to install secret management operator and all its dependencies
 
 **Contents:**
 
@@ -63,7 +63,7 @@ We will getting them from `external-secrets` repository
 
 ```yaml
 # GitRepository
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: external-secrets
@@ -93,7 +93,7 @@ We will getting them from `external-secrets` repository as well
 ```yaml
 ---
 # external secrets crds
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: external-secrets-crds
@@ -144,14 +144,14 @@ spec:
 ---
 ```
 
-4- External Secrets Secrets (CRs) 
+4- External Secrets Secrets (CRs)
 
 In this guide the secrets are in the same repository you can create as many CRs as you need, this is one secret for elaboration
 
 ```yaml
 ---
 # external secrets secrets
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: external-secrets-secrets
@@ -166,7 +166,6 @@ spec:
     name: flux-system
   path: ./secrets
   prune: true
-  validation: client
 ```
 
 - ***clusters/my-cluster/cluster-secrets***
@@ -176,7 +175,7 @@ This is the Kustomization file, the manifest of external secrets resources
 **Contents:**
 
 ```yaml
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: cluster-secrets
@@ -188,7 +187,6 @@ spec:
     name: flux-system
   path: ../cluster-secrets
   prune: true
-  validation: client
 ```
 
 - ***secrets/aws-secret-store.yaml***
@@ -330,7 +328,7 @@ kubectl create secret generic ssh-credentials --from-file=./identity --from-file
 **Goal**: To bootstrap the leaf cluster with flux installed & secret to authenticate ESO
 
 
-**Structure** 
+**Structure**
 
 ```yaml
 ➜  wge-dev git:(main) tree
@@ -364,7 +362,7 @@ kubectl create secret generic ssh-credentials --from-file=./identity --from-file
         └── prod
 ```
 
-**1- How to create the secret** 
+**1- How to create the secret**
 
 - First when creating the management cluster we will need to create manually a secret for authenticating the SecretStore also we need to create`ClusterResourceSet` for the AWS secret to be able to bootstrap it to leaf cluster. This will be copied for bootstrap location as shown before.
 
@@ -433,7 +431,7 @@ For the cluster template we will need to add 2 labels
 
 i) `weave.works/flux: bootstrap` to match the booting clusters with the `**ClusterBootstrapConfig`** job
 
-ii) `secretmanager: aws` to match the the booting clusters with the `ClusterResourceSet` for the AWS secret 
+ii) `secretmanager: aws` to match the the booting clusters with the `ClusterResourceSet` for the AWS secret
 
 Example for the template
 

--- a/charts/external-secrets/Chart.yaml
+++ b/charts/external-secrets/Chart.yaml
@@ -3,7 +3,7 @@ name: external-secrets
 icon: https://raw.githubusercontent.com/external-secrets/external-secrets/main/assets/eso-round-logo.svg
 description: A Weaveworks Helm chart for the External Secrets Operator
 type: application
-version: 0.6.2
+version: 1.0.0
 dependencies:
 - name: external-secrets
   version: "0.6.1"

--- a/charts/external-secrets/Chart.yaml
+++ b/charts/external-secrets/Chart.yaml
@@ -3,7 +3,7 @@ name: external-secrets
 icon: https://raw.githubusercontent.com/external-secrets/external-secrets/main/assets/eso-round-logo.svg
 description: A Weaveworks Helm chart for the External Secrets Operator
 type: application
-version: 0.6.1
+version: 0.6.2
 dependencies:
 - name: external-secrets
   version: "0.6.1"

--- a/charts/external-secrets/templates/secret-stores-kustomization.yaml
+++ b/charts/external-secrets/templates/secret-stores-kustomization.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.secretStores.enabled }}
 {{- if not .Values.secretStores.sourceRef }}
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: external-secrets
@@ -23,7 +23,7 @@ spec:
   {{- end }}
 {{- end }}
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: external-secrets
@@ -41,5 +41,4 @@ spec:
   {{- end }}
   path: {{ .Values.secretStores.path }}
   prune: true
-  validation: client
 {{- end }}

--- a/charts/weave-policy-agent/Chart.lock
+++ b/charts/weave-policy-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: policy-agent
   repository: https://weaveworks.github.io/policy-agent
-  version: 2.4.0
-digest: sha256:63bbeef8a270e044ed55e6a4655cfffbfa926f7ceb1875f8e4a0fec5a37930ab
-generated: "2023-05-31T13:38:48.782795865+03:00"
+  version: 2.5.0
+digest: sha256:2c8e91250a08f5d899643aeead53548322fba11b526628a581d95c322e7fb2c7
+generated: "2023-06-18T17:33:42.300971762+03:00"

--- a/charts/weave-policy-agent/Chart.lock
+++ b/charts/weave-policy-agent/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: policy-agent
   repository: https://weaveworks.github.io/policy-agent
-  version: 2.3.0
-digest: sha256:cd5b8802d4cd48cc47c6436a3248f912cabc9a79bf777c19400199000da16380
-generated: "2023-02-19T16:42:00.796036351+02:00"
+  version: 2.4.0
+digest: sha256:63bbeef8a270e044ed55e6a4655cfffbfa926f7ceb1875f8e4a0fec5a37930ab
+generated: "2023-05-31T13:38:48.782795865+03:00"

--- a/charts/weave-policy-agent/Chart.lock
+++ b/charts/weave-policy-agent/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://weaveworks.github.io/policy-agent
   version: 2.5.0
 digest: sha256:2c8e91250a08f5d899643aeead53548322fba11b526628a581d95c322e7fb2c7
-generated: "2023-06-18T17:33:42.300971762+03:00"
+generated: "2023-06-26T14:47:54.260827988+03:00"

--- a/charts/weave-policy-agent/Chart.yaml
+++ b/charts/weave-policy-agent/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 description: A Weaveworks Helm chart for Kubernetes to configure the policy agent
 name: weave-policy-agent
-appVersion: "2.4.0"
+appVersion: "2.5.0"
 version: 1.0.0
 kubeVersion: ">=1.16.0-0"
 icon: https://www.magalix.com/hubfs/Imported%20images/logo-02.png%3Fwidth=560%26name=logo-02-Dec-18-2020-11-24-41-75-AM.png
@@ -30,5 +30,5 @@ annotations:
 
 dependencies:
   - name: policy-agent
-    version: "2.4.0"
+    version: "2.5.0"
     repository: "https://weaveworks.github.io/policy-agent"

--- a/charts/weave-policy-agent/Chart.yaml
+++ b/charts/weave-policy-agent/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 description: A Weaveworks Helm chart for Kubernetes to configure the policy agent
 name: weave-policy-agent
-appVersion: "2.3.0"
-version: 0.6.7
+appVersion: "2.4.0"
+version: 0.6.8
 kubeVersion: ">=1.16.0-0"
 icon: https://www.magalix.com/hubfs/Imported%20images/logo-02.png%3Fwidth=560%26name=logo-02-Dec-18-2020-11-24-41-75-AM.png
 type: application
@@ -28,5 +28,5 @@ annotations:
 
 dependencies:
   - name: policy-agent
-    version: "2.3.0"
+    version: "2.4.0"
     repository: "https://weaveworks.github.io/policy-agent"

--- a/charts/weave-policy-agent/Chart.yaml
+++ b/charts/weave-policy-agent/Chart.yaml
@@ -19,6 +19,8 @@ maintainers:
 
 annotations:
   "weave.works/profile": weave-policy
+  "weave.works/profile-ci": |
+    - "kind"
   "weave.works/layer": layer-1
   "weave.works/category": Policy
   "weave.works/operator": "true"

--- a/charts/weave-policy-agent/Chart.yaml
+++ b/charts/weave-policy-agent/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 description: A Weaveworks Helm chart for Kubernetes to configure the policy agent
 name: weave-policy-agent
 appVersion: "2.4.0"
-version: 0.6.8
+version: 1.0.0
 kubeVersion: ">=1.16.0-0"
 icon: https://www.magalix.com/hubfs/Imported%20images/logo-02.png%3Fwidth=560%26name=logo-02-Dec-18-2020-11-24-41-75-AM.png
 type: application

--- a/charts/weave-policy-agent/templates/policy-library.yaml
+++ b/charts/weave-policy-agent/templates/policy-library.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.policySource.enabled }}
 {{- if not .Values.policySource.sourceRef }}
-apiVersion: source.toolkit.fluxcd.io/v1beta1
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
 metadata:
   name: policy-library
@@ -23,7 +23,7 @@ spec:
   {{- end }}
 {{- end }}
 ---
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: policy-library
@@ -41,5 +41,4 @@ spec:
   {{- end }}
   path: {{ .Values.policySource.path }}
   prune: true
-  validation: client
 {{- end }}

--- a/charts/weave-policy-agent/values.yaml
+++ b/charts/weave-policy-agent/values.yaml
@@ -36,12 +36,12 @@ policy-agent:
 
 
 policySource:
-  enabled: true
-  url: ssh://git@github.com/weaveworks/policy-library
-  tag: v1.0.0
+  enabled: false
+  # url: ssh://git@github.com/weaveworks/policy-library
+  # tag: v1.0.0
   # branch:
-  path: ./  # Could be a path to the policies dir or a kustomization.yaml file
-  secretRef: policy-library-auth  # (Optional): Name of the K8s secret with private repo auth credentials
+  # path: ./  # Could be a path to the policies dir or a kustomization.yaml file
+  # secretRef: policy-library-auth  # (Optional): Name of the K8s secret with private repo auth credentials
   # sourceRef: # Could specify a name for an existing GitSource reference instead of creating a new one
   #   kind: GitRepository
   #   name: policy-library

--- a/charts/weave-policy-agent/values.yaml
+++ b/charts/weave-policy-agent/values.yaml
@@ -36,12 +36,12 @@ policy-agent:
 
 
 policySource:
-  enabled: false
-  # url: ssh://git@github.com/weaveworks/policy-library
-  # tag: v1.0.0
+  enabled: true
+  url: ssh://git@github.com/weaveworks/policy-library
+  tag: v1.0.0
   # branch:
-  # path: ./  # Could be a path to the policies dir or a kustomization.yaml file
-  # secretRef: policy-library-auth  # (Optional): Name of the K8s secret with private repo auth credentials
+  path: ./  # Could be a path to the policies dir or a kustomization.yaml file
+  secretRef: policy-library-auth  # (Optional): Name of the K8s secret with private repo auth credentials
   # sourceRef: # Could specify a name for an existing GitSource reference instead of creating a new one
   #   kind: GitRepository
   #   name: policy-library


### PR DESCRIPTION
This PR upgrades charts that create Kustomization and GitRepository `v1beta2` CRs to `v1` CRs.